### PR TITLE
Replace bad characters from the query 

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,8 @@ Client.prototype.search = function (query, options) {
 		throw new TypeError('Expected a query');
 	}
 
+	query = query.replace(/[- ]/g, '');
+
 	return got(this.endpoint + '/customsearch/v1', {
 		query: this._buildOptions(query, options),
 		json: true


### PR DESCRIPTION
Fix for the issue [#17](https://github.com/vdemedes/google-images/issues/17) 

Avoid getting an undefined `res.body.items` if there are dashes or spaces in the query string